### PR TITLE
feat: switch tab feature (#23)

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -61,26 +61,33 @@ const EXPLORERS: { [env: string]: { [explorer: string]: string } } = {
     etherscan: "https://no-expolorers-for-local-e2e/",
     subscan_ah: "https://no-expolorers-for-local-e2e/",
     subscan_bh: "https://no-expolorers-for-local-e2e/",
+    polkadot_js_kilt: "https://no-expolorers-for-westend/",
   },
   rococo_sepolia: {
     etherscan: "https://sepolia.etherscan.io/",
     subscan_ah: "https://assethub-rococo.subscan.io/",
     subscan_bh: "https://bridgehub-rococo.subscan.io/",
+    polkadot_js_kilt:
+      "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frilt.kilt.io/",
   },
   paseo_sepolia: {
     etherscan: "https://sepolia.etherscan.io/",
     subscan_ah: "https://assethub-paseo.subscan.io/",
     subscan_bh: "https://bridgehub-paseo.subscan.io/",
+    polkadot_js_kilt:
+      "https://polkadot.js.org/apps/?rpc=wss://peregrine.kilt.io/parachain-public-ws/",
   },
   polkadot_mainnet: {
     etherscan: "https://etherscan.io/",
     subscan_ah: "https://assethub-polkadot.subscan.io/",
     subscan_bh: "https://bridgehub-polkadot.subscan.io/",
+    subscan_kilt: "https://spiritnet.subscan.io/",
   },
   westend_sepolia: {
     etherscan: "https://sepolia.etherscan.io/",
     subscan_ah: "https://assethub-westend.subscan.io/",
     subscan_bh: "https://bridgehub-westend.subscan.io/",
+    polkadot_js_kilt: "https://no-expolorers-for-westend/",
   },
 };
 
@@ -295,8 +302,8 @@ const transferTitle = (
     history.TransferStatus.Failed == transfer.status
       ? " bg-destructive"
       : history.TransferStatus.Pending == transfer.status
-      ? ""
-      : "bg-secondary";
+        ? ""
+        : "bg-secondary";
 
   const { tokenName, amount } = formatTokenData(
     transfer,

--- a/app/switch/page.tsx
+++ b/app/switch/page.tsx
@@ -1,0 +1,10 @@
+import { ContextComponent } from "@/components/Context";
+import { SwitchComponent } from "@/components/Switch";
+
+export default function Switch() {
+  return (
+    <ContextComponent>
+      <SwitchComponent />
+    </ContextComponent>
+  );
+}

--- a/components/Balances.tsx
+++ b/components/Balances.tsx
@@ -1,0 +1,306 @@
+import { snowbridgeContextAtom } from "@/store/snowbridge";
+import { fetchForeignAssetsBalances } from "@/utils/balances";
+import { formatBalance } from "@/utils/formatting";
+import { ParaConfig } from "@/utils/parachainConfigs";
+import { ErrorInfo } from "@/utils/types";
+import { ApiPromise } from "@polkadot/api";
+import { Option } from "@polkadot/types";
+import { AccountInfo, AssetBalance } from "@polkadot/types/interfaces";
+import { assets } from "@snowbridge/api";
+import { useAtomValue } from "jotai";
+import React, { useState, useEffect, useCallback, FC } from "react";
+
+interface Props {
+  sourceAccount: string;
+  sourceId: string;
+  destinationId: string;
+  beneficiary: string;
+  parachainInfo: ParaConfig[];
+  handleSufficientTokens: (
+    assetHubSufficient: boolean,
+    parachainSufficient: boolean,
+  ) => void;
+  handleTopUpCheck: (
+    xcmFee: bigint,
+    xcmBalance: bigint,
+    xcmBalanceDestination: bigint,
+  ) => void;
+  handleBalanceCheck: (fetchBalance: string) => void;
+}
+
+// Utility function to query balances
+const getBalanceData = async (
+  api: ApiPromise,
+  account: string,
+  decimals: number,
+) => {
+  const {
+    //@ts-ignore -- Unfortunately, the typing isn't upto date
+    data: { free, frozen },
+  } = await api.query.system.account<AccountInfo>(account);
+
+  return formatBalance({
+    number: free.toBigInt() - frozen.toBigInt(),
+    decimals,
+    displayDecimals: 3,
+  });
+};
+
+const PolkadotBalance: FC<Props> = ({
+  sourceAccount,
+  sourceId,
+  destinationId,
+  beneficiary,
+  parachainInfo,
+  handleSufficientTokens,
+  handleTopUpCheck,
+  handleBalanceCheck,
+}) => {
+  const context = useAtomValue(snowbridgeContextAtom);
+  const [balanceData, setBalanceData] = useState({
+    destinationBalance: "0",
+    destinationSymbol: "",
+    destinationName: "",
+    sourceBalance: "0",
+    sourceSymbol: "",
+    sourceName: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorInfo | null>(null);
+
+  const checkXcmFee = useCallback(async () => {
+    if (!context || !sourceAccount) return;
+    if (sourceId === destinationId) return;
+
+    try {
+      const parachainId =
+        destinationId === "assethub" ? sourceId : destinationId;
+      const parachain = parachainInfo.find((val) => val.id === parachainId);
+
+      if (!parachain) return;
+      const api = context.polkadot.api.parachains[parachain.parachainId];
+      const { xcmFee } = parachain.switchPair[0];
+
+      const assetHubBalanceDestination =
+        await context.polkadot.api.assetHub.query.system.account<AccountInfo>(
+          sourceAccount,
+        );
+
+      const fungibleBalance = await api.query.fungibles.account<
+        Option<AssetBalance>
+      >(parachain.switchPair[0].xcmFee.remoteXcmFee.V4.id, sourceAccount);
+
+      setError(null);
+
+      handleTopUpCheck(
+        BigInt(xcmFee.amount),
+        fungibleBalance.unwrapOrDefault().balance.toBigInt(),
+        assetHubBalanceDestination.data.free.toBigInt() -
+          //@ts-ignore -- Unfortunately, doesn't exist in the polkadot typing
+          assetHubBalanceDestination.data.frozen.toBigInt(),
+      );
+    } catch (error) {
+      console.error(error);
+      setError({
+        title: "Unable to retrieve XCM fee balance",
+        description:
+          "Unable to get the accounts data and see if there are any tokens for the XCM balance",
+        errors: [],
+      });
+    }
+  }, [
+    context,
+    destinationId,
+    handleTopUpCheck,
+    parachainInfo,
+    sourceAccount,
+    sourceId,
+  ]);
+
+  const checkSufficientTokens = useCallback(async () => {
+    if (!context || !beneficiary) return;
+    try {
+      const parachainId =
+        destinationId === "assethub" ? sourceId : destinationId;
+
+      const assetHubApi = context.polkadot.api.assetHub;
+      const finder = parachainInfo.find((val) => val.id === parachainId);
+      if (!finder) return;
+      const parachainApi = context.polkadot.api.parachains[finder.parachainId];
+
+      const checkAssetHubBalanceED =
+        await assetHubApi.query.system.account<AccountInfo>(beneficiary);
+
+      const assetHubSufficient =
+        checkAssetHubBalanceED.sufficients.gtn(0) ||
+        checkAssetHubBalanceED.providers.gtn(0);
+
+      const checkParachainBalanceED =
+        await parachainApi.query.system.account<AccountInfo>(beneficiary);
+
+      const parachainSufficient =
+        checkParachainBalanceED.sufficients.gtn(0) ||
+        checkParachainBalanceED.providers.gtn(0);
+
+      handleSufficientTokens(assetHubSufficient, parachainSufficient);
+      setError(null);
+    } catch (e) {
+      console.error(e);
+      setError({
+        title: "Unable to retrieve sufficients",
+        description:
+          "Unable to get the accounts data and see if there are any tokens",
+        errors: [],
+      });
+    }
+  }, [
+    beneficiary,
+    context,
+    destinationId,
+    handleSufficientTokens,
+    parachainInfo,
+    sourceId,
+  ]);
+
+  const fetchBalanceData = useCallback(async () => {
+    if (!context || !sourceAccount) return;
+    if (sourceId === destinationId) return;
+
+    try {
+      const parachain =
+        sourceId === "assethub"
+          ? parachainInfo.find((val) => val.id === destinationId)
+          : parachainInfo.find((val) => val.id === sourceId);
+
+      if (!parachain) {
+        return;
+      }
+      const sourceApi =
+        sourceId === "assethub"
+          ? context.polkadot.api.assetHub
+          : context.polkadot.api.parachains[parachain.parachainId!];
+
+      const destinationApi =
+        destinationId === "assethub"
+          ? context.polkadot.api.assetHub
+          : context.polkadot.api.parachains[parachain.parachainId!];
+
+      if (sourceId === "assethub") {
+        const sourceBalance = await fetchForeignAssetsBalances(
+          sourceApi,
+          parachain.switchPair[0].remoteAssetId,
+          sourceAccount,
+          parachain.switchPair[0].tokenMetadata.decimals,
+        );
+
+        const destinationBalance = await getBalanceData(
+          destinationApi,
+          sourceAccount,
+          parachain.switchPair[0].tokenMetadata.decimals,
+        );
+
+        setBalanceData({
+          destinationBalance,
+          destinationSymbol: parachain.switchPair[0].tokenMetadata.symbol,
+          destinationName: parachain.name,
+          sourceBalance,
+          sourceSymbol: parachain.switchPair[0].tokenMetadata.symbol,
+          sourceName: "Asset Hub",
+        });
+        handleBalanceCheck(sourceBalance);
+      } else {
+        const { tokenDecimal, tokenSymbol } =
+          await assets.parachainNativeAsset(sourceApi);
+        const sourceBalance = await getBalanceData(
+          sourceApi,
+          sourceAccount,
+          tokenDecimal,
+        );
+
+        const destinationBalance = await fetchForeignAssetsBalances(
+          destinationApi,
+          parachain.switchPair[0].remoteAssetId,
+          sourceAccount,
+          parachain.switchPair[0].tokenMetadata.decimals,
+        );
+
+        setBalanceData({
+          destinationBalance,
+          destinationSymbol: parachain.switchPair[0].tokenMetadata.symbol,
+          destinationName: "Asset Hub",
+          sourceBalance,
+          sourceSymbol: tokenSymbol,
+          sourceName: parachain.name,
+        });
+        handleBalanceCheck(sourceBalance);
+      }
+
+      setError(null);
+      setLoading(false);
+    } catch (err) {
+      console.error(err);
+      setError({
+        title: "Error",
+        description: "Could not fetch balance.",
+        errors: [],
+      });
+      setLoading(false);
+    }
+  }, [
+    context,
+    destinationId,
+    handleBalanceCheck,
+    parachainInfo,
+    sourceAccount,
+    sourceId,
+  ]);
+
+  useEffect(() => {
+    checkXcmFee();
+    const iv = setInterval(checkXcmFee, 10000);
+    return () => clearInterval(iv);
+  }, [checkXcmFee]);
+
+  useEffect(() => {
+    fetchBalanceData();
+    const iv = setInterval(fetchBalanceData, 10000);
+    return () => clearInterval(iv);
+  }, [fetchBalanceData]);
+
+  useEffect(() => {
+    checkSufficientTokens();
+    const iv = setInterval(checkSufficientTokens, 10000);
+    return () => clearInterval(iv);
+  }, [checkSufficientTokens]);
+
+  if (loading) {
+    return (
+      <div className="text-sm text-right text-muted-foreground px-1">
+        Fetching...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-right text-muted-foreground px-1">
+        {error.description}
+      </div>
+    );
+  }
+  const { destinationBalance, destinationSymbol, sourceBalance, sourceSymbol } =
+    balanceData;
+
+  return (
+    <>
+      <div className="text-sm text-right text-muted-foreground px-1">
+        Source Balance: {sourceBalance} {sourceSymbol}
+      </div>
+      <div className="text-sm text-right text-muted-foreground px-1">
+        Destination Balance: {destinationBalance} {destinationSymbol}
+      </div>
+    </>
+  );
+};
+
+export default PolkadotBalance;

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -15,6 +15,7 @@ import {
 import { useAtom, useAtomValue } from "jotai";
 import {
   Github,
+  LucideArrowRightLeft,
   LucideBarChart,
   LucideBookText,
   LucideBug,
@@ -132,6 +133,16 @@ export const Menu: FC = () => {
             </Link>
           </MenubarTrigger>
         </MenubarMenu>
+        {envName === "westend_sepolia" ? null : (
+        <MenubarMenu>
+          <MenubarTrigger>
+            <Link href="/switch" className="flex items-center">
+              <LucideArrowRightLeft />
+                <p className="pl-2 hidden md:flex">Polar Path</p>
+            </Link>
+          </MenubarTrigger>
+        </MenubarMenu>
+        )}
         <MenubarMenu>
           <MenubarTrigger>
             <Link href="/status" className="flex items-center">

--- a/components/SelectAccount.tsx
+++ b/components/SelectAccount.tsx
@@ -5,7 +5,7 @@ import {
   polkadotWalletModalOpenAtom,
 } from "@/store/polkadot";
 import { useAtom, useAtomValue } from "jotai";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import {
@@ -23,16 +23,30 @@ type SelectAccountProps = {
   field: any;
   allowManualInput: boolean;
   accounts: AccountInfo[];
+  disabled?: boolean;
 };
 
 export const SelectAccount: FC<SelectAccountProps> = ({
   field,
   allowManualInput,
   accounts,
+  disabled = false,
 }) => {
   const [accountFromWallet, setBeneficiaryFromWallet] = useState(true);
   const polkadotAccounts = useAtomValue(polkadotAccountsAtom);
   const [, setPolkadotWalletModalOpen] = useAtom(polkadotWalletModalOpenAtom);
+
+  useEffect(() => {
+    // unset account selection if selected account is no longer found in accounts
+    if (
+      !allowManualInput &&
+      !accounts.find((account) => account.key === field.value)
+    ) {
+      field.onChange(undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- watching for 'field' would introduce infinite loop
+  }, [accounts, field.value, allowManualInput]);
+
   if (
     !allowManualInput &&
     accountFromWallet &&
@@ -53,10 +67,6 @@ export const SelectAccount: FC<SelectAccountProps> = ({
     );
   }
 
-  if (!accounts.find((account) => account.key === field.value)) {
-    field.onChange(undefined);
-  }
-
   let input: JSX.Element;
   if (!allowManualInput && accountFromWallet && accounts.length > 0) {
     input = (
@@ -64,6 +74,7 @@ export const SelectAccount: FC<SelectAccountProps> = ({
         key="controlled"
         onValueChange={field.onChange}
         value={field.value}
+        disabled={disabled}
       >
         <SelectTrigger>
           <SelectValue placeholder="Select account" />

--- a/components/SendErrorDialog.tsx
+++ b/components/SendErrorDialog.tsx
@@ -5,14 +5,19 @@ import { ErrorDialog } from "./ErrorDialog";
 import { Button } from "./ui/button";
 import { getDestinationTokenIdByAddress } from "../utils/getDestinationTokenIdByAddress";
 import { userFriendlyErrorMessage } from "../utils/userFriendlyErrorMessage";
-import { ErrorInfo, FormData, ValidationError } from "@/utils/types";
+import {
+  ErrorInfo,
+  FormData,
+  FormDataSwitch,
+  ValidationError,
+} from "@/utils/types";
 
 export const SendErrorDialog: FC<{
   info: ErrorInfo | null;
   formData: FormData;
-  destination: environment.TransferLocation;
-  onDepositAndApproveWeth: () => Promise<void>;
-  onApproveSpend: () => Promise<void>;
+  destination?: environment.TransferLocation;
+  onDepositAndApproveWeth?: () => Promise<void>;
+  onApproveSpend?: () => Promise<void>;
   dismiss: () => void;
 }> = ({
   info,

--- a/components/Switch.tsx
+++ b/components/Switch.tsx
@@ -1,0 +1,606 @@
+"use client";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import {
+  assetHubToParachainTransfer,
+  parachainToAssetHubTransfer,
+} from "@/utils/onSwitch";
+import { polkadotAccountAtom, polkadotAccountsAtom } from "@/store/polkadot";
+import {
+  snowbridgeEnvironmentAtom,
+  snowbridgeContextAtom,
+} from "@/store/snowbridge";
+import { useAtomValue } from "jotai";
+import { formSchemaSwitch } from "@/utils/formSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, UseFormReturn } from "react-hook-form";
+import { z } from "zod";
+import { AccountInfo, ErrorInfo, FormDataSwitch } from "@/utils/types";
+import { SelectedPolkadotAccount } from "./SelectedPolkadotAccount";
+import { SelectAccount } from "./SelectAccount";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { BusyDialog } from "./BusyDialog";
+import { SendErrorDialog } from "./SendErrorDialog";
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { ISubmittableResult } from "@polkadot/types/types";
+import PolkadotBalance from "./Balances";
+import { parseUnits } from "ethers";
+import { toast } from "sonner";
+import {
+  parachainConfigs,
+  SnowbridgeEnvironmentNames,
+} from "@/utils/parachainConfigs";
+
+import { TopUpXcmFee } from "./TopUpXcmFee";
+import { toPolkadot } from "@snowbridge/api";
+import { formatBalance } from "@/utils/formatting";
+
+export const SwitchComponent: FC = () => {
+  const snowbridgeEnvironment = useAtomValue(snowbridgeEnvironmentAtom);
+  const context = useAtomValue(snowbridgeContextAtom);
+  const polkadotAccounts = useAtomValue(polkadotAccountsAtom);
+  const polkadotAccount = useAtomValue(polkadotAccountAtom);
+
+  const [feeDisplay, setFeeDisplay] = useState("");
+  const [balanceCheck, setBalanceCheck] = useState("");
+
+  const [error, setError] = useState<ErrorInfo | null>(null);
+  const [busyMessage, setBusyMessage] = useState("");
+  const [
+    assetHubSufficientTokenAvailable,
+    setAssetHubSufficientTokenAvailable,
+  ] = useState(true);
+  const [
+    parachainSufficientTokenAvailable,
+    setParachainSufficientTokenAvailable,
+  ] = useState(true);
+  const [topUpCheck, setTopUpCheck] = useState({
+    xcmFee: 0n,
+    xcmBalance: 0n,
+    xcmBalanceDestination: 0n,
+  });
+  const [transaction, setTransaction] = useState<SubmittableExtrinsic<
+    "promise",
+    ISubmittableResult
+  > | null>(null);
+
+  const parachainsInfo =
+    parachainConfigs[snowbridgeEnvironment.name as SnowbridgeEnvironmentNames];
+
+  const [tokenSymbol, setTokenSymbol] = useState<string | null>(
+    parachainsInfo[0]?.switchPair[0]?.tokenMetadata.symbol,
+  );
+
+  const form: UseFormReturn<FormDataSwitch> = useForm<
+    z.infer<typeof formSchemaSwitch>
+  >({
+    resolver: zodResolver(formSchemaSwitch),
+    defaultValues: {
+      source: "assethub",
+      destination: parachainsInfo[0]?.id,
+      token: parachainsInfo[0]?.switchPair[0]?.tokenMetadata.symbol,
+      amount: "0.0",
+    },
+  });
+
+  const sourceId = form.watch("source");
+  const destinationId = form.watch("destination");
+  const beneficiary = form.watch("beneficiary");
+  const amount = form.watch("amount");
+  const watchSourceAccount = form.watch("sourceAccount");
+
+  const [sourceAccount, setSourceAccount] = useState<string | undefined>(
+    polkadotAccount?.address,
+  );
+
+  useEffect(() => {
+    setSourceAccount(polkadotAccount?.address);
+    form.resetField("sourceAccount", {
+      defaultValue: polkadotAccount?.address,
+    });
+    form.resetField("beneficiary", { defaultValue: polkadotAccount?.address });
+  }, [watchSourceAccount, polkadotAccount, form]);
+
+  const beneficiaries: AccountInfo[] = useMemo(
+    () =>
+      polkadotAccounts?.map((x) => ({
+        key: x.address,
+        name: x.name || "",
+        type: "substrate",
+      })) || [],
+    [polkadotAccounts],
+  );
+
+  useEffect(() => {
+    if (sourceId === "assethub") {
+      if (!parachainsInfo.some(({ id }) => id === destinationId)) {
+        form.resetField("destination", {
+          defaultValue: parachainsInfo[0]?.id,
+        });
+      }
+    } else {
+      form.resetField("destination", {
+        defaultValue: "assethub",
+      });
+    }
+  }, [destinationId, form, parachainsInfo, sourceId]);
+
+  const buildTransaction = useCallback(async () => {
+    if (
+      !context ||
+      !beneficiary ||
+      !sourceId ||
+      !destinationId ||
+      !sourceAccount
+    ) {
+      return;
+    }
+
+    if (!(Number(amount) > 0)) {
+      return;
+    }
+    try {
+      let transaction;
+
+      if (sourceId === "assethub") {
+        if (destinationId === "assethub") {
+          return;
+        }
+        const destination = parachainsInfo.find(
+          ({ id }) => id === destinationId,
+        )!;
+        // take first switch pair - may be selectable in future version
+        const switchPair = destination.switchPair[0];
+        setTokenSymbol(switchPair.tokenMetadata.symbol);
+
+        transaction = await assetHubToParachainTransfer({
+          context,
+          beneficiary,
+          paraId: destination.parachainId,
+          palletName: switchPair.id,
+          amount: parseUnits(amount, switchPair.tokenMetadata.decimals),
+        });
+      } else {
+        const { parachainId, switchPair } = parachainsInfo.find(
+          ({ id }) => id === sourceId,
+        )!; // TODO: handle not exists?
+
+        setTokenSymbol(switchPair[0].tokenMetadata.symbol);
+
+        transaction = await parachainToAssetHubTransfer({
+          context,
+          beneficiary,
+          amount: parseUnits(amount, switchPair[0].tokenMetadata.decimals),
+          parachainId,
+          palletName: switchPair[0].id,
+        });
+      }
+      const transactionFee = await transaction.paymentInfo(sourceAccount);
+
+      setTransaction(transaction);
+      setFeeDisplay(transactionFee.partialFee.toHuman());
+    } catch (err) {
+      console.error(err);
+      setError({
+        title: "Send Error",
+        description: `Error occured while trying to create transaction.`,
+        errors: [],
+      });
+    }
+  }, [
+    context,
+    beneficiary,
+    sourceId,
+    destinationId,
+    sourceAccount,
+    amount,
+    parachainsInfo,
+  ]);
+
+  useEffect(() => {
+    setTransaction(null);
+    const timeout = setTimeout(buildTransaction, 700);
+    return () => clearTimeout(timeout);
+  }, [buildTransaction]);
+
+  const handleSufficientTokens = (
+    assetHubSufficient: boolean,
+    parachainSufficient: boolean,
+  ) => {
+    setAssetHubSufficientTokenAvailable(assetHubSufficient);
+    setParachainSufficientTokenAvailable(parachainSufficient);
+  };
+  const handleBalanceCheck = (fetchBalance: string) => {
+    setBalanceCheck(fetchBalance);
+  };
+  const handleTopUpCheck = useCallback(
+    (xcmFee: bigint, xcmBalance: bigint, xcmBalanceDestination: bigint) => {
+      setTopUpCheck({ xcmFee, xcmBalance, xcmBalanceDestination });
+    },
+    [],
+  );
+  const onSubmit = useCallback(async () => {
+    if (!transaction || !context) {
+      return;
+    }
+
+    try {
+      if (destinationId === "assethub") {
+        if (!assetHubSufficientTokenAvailable) {
+          setError({
+            title: "Insufficient Tokens.",
+            description:
+              "Your account on Asset Hub does not have the required tokens. Please ensure you meet the sufficient or existential deposit requirements.",
+            errors: [
+              {
+                kind: "toPolkadot",
+                code: toPolkadot.SendValidationCode.BeneficiaryAccountMissing,
+                message:
+                  "To complete the transaction, your Asset Hub account must hold specific tokens. Without these, the account cannot be activated or used.",
+              },
+            ],
+          });
+          return;
+        }
+        if (topUpCheck.xcmFee >= topUpCheck.xcmBalance) {
+          // this shouldn't really happen because it should be caught by the top up dialogue
+          setError({
+            title: "Insufficient XCM Remote Fee Payment Tokens.",
+            description:
+              "Switches with destination Asset Hub require you to hold Relay Chain native tokens (e.g., DOT) on the source chain. You can teleport or reserve-transfer tokens to meet these requirements.",
+            errors: [],
+          });
+
+          return;
+        }
+      }
+
+      if (!parachainSufficientTokenAvailable) {
+        setError({
+          title: "Insufficient Tokens.",
+          description:
+            "The beneficiary's account does not meet the sufficient or existential deposit requirements. Please ensure they have enough funds on the destination account to complete the transaction.",
+          errors: [],
+        });
+        return;
+      }
+
+      if (Number(balanceCheck) < Number(amount)) {
+        setError({
+          title: "Transfer amount below balance.",
+          description:
+            "The source's account does have enough balance to complete the transaction. Please ensure you have enough funds to complete the transaction.",
+          errors: [],
+        });
+        return;
+      }
+
+      const { signer, address } = polkadotAccounts?.find(
+        (val) => val.address === sourceAccount,
+      )!;
+      if (!signer) {
+        throw new Error("Signer is not available");
+      }
+      setBusyMessage("Waiting for transaction to be confirmed by wallet.");
+
+      const subscanHost =
+        sourceId === "assethub"
+          ? "https://assethub-polkadot.subscan.io"
+          : "https://spiritnet.subscan.io";
+      await transaction.signAndSend(address, { signer }, (result) => {
+        setBusyMessage("Currently in flight");
+
+        if (result.isFinalized && !result.dispatchError) {
+          setBusyMessage("");
+          toast.info("Transfer Successful", {
+            position: "bottom-center",
+            closeButton: true,
+            duration: 60000,
+            id: "transfer_success",
+            description: "Token transfer was succesfully initiated.",
+            important: true,
+            action: {
+              label: "View",
+              onClick: () =>
+                window.open(
+                  `${subscanHost}/extrinsic/${result.txHash}`,
+                  "_blank",
+                ),
+            },
+          });
+        } else if (result.isError || result.dispatchError) {
+          setBusyMessage("");
+          toast.info("Transfer unsuccessful", {
+            position: "bottom-center",
+            closeButton: true,
+            duration: 60000,
+            id: "transfer_error",
+            description: "Token transfer was unsuccesful.",
+            important: true,
+            action: {
+              label: "View",
+              onClick: () =>
+                window.open(
+                  `${subscanHost}/extrinsic/${result.txHash}`,
+                  "_blank",
+                ),
+            },
+          });
+        }
+      });
+
+      setBusyMessage("");
+    } catch (err) {
+      setBusyMessage("");
+      setError({
+        title: "Transaction Failed",
+        description: `Error occured while trying to send transaction.`,
+        errors: [],
+      });
+    }
+  }, [
+    transaction,
+    context,
+    destinationId,
+    parachainSufficientTokenAvailable,
+    balanceCheck,
+    amount,
+    polkadotAccounts,
+    sourceId,
+    assetHubSufficientTokenAvailable,
+    topUpCheck.xcmFee,
+    topUpCheck.xcmBalance,
+    sourceAccount,
+  ]);
+
+  return (
+    <>
+      <Card className="w-auto md:w-2/3">
+        <CardHeader>
+          <CardTitle>Polar Path</CardTitle>
+          <CardDescription className="hidden md:flex">
+            Switch Parachain tokens for ERC-20 Parachain tokens via Asset Hub.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(() => onSubmit())}
+              className="space-y-2"
+            >
+              <div className="grid grid-cols-2 space-x-2">
+                <FormField
+                  control={form.control}
+                  name="source"
+                  render={({ field }) => (
+                    <FormItem {...field}>
+                      <FormLabel>Source</FormLabel>
+                      <FormControl>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a source" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {[
+                                { id: "assethub", name: "Asset Hub" },
+                                ...parachainsInfo,
+                              ].map(({ id, name }) => (
+                                <SelectItem key={id} value={id}>
+                                  {name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="destination"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Destination</FormLabel>
+                      <FormControl>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a destination" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {sourceId !== "assethub" ? (
+                                <SelectItem key={"assethub"} value={"assethub"}>
+                                  Asset Hub
+                                </SelectItem>
+                              ) : (
+                                parachainsInfo.map(({ id, name }) => (
+                                  <SelectItem key={id} value={id}>
+                                    {name}
+                                  </SelectItem>
+                                ))
+                              )}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="sourceAccount"
+                render={({ field }) => (
+                  <FormItem {...field}>
+                    <FormLabel>Source Account</FormLabel>
+                    <FormDescription className="hidden md:flex">
+                      Account on the source.
+                    </FormDescription>
+                    <FormControl>
+                      <>
+                        <SelectedPolkadotAccount />
+                        <PolkadotBalance
+                          sourceAccount={sourceAccount ?? ""}
+                          sourceId={sourceId}
+                          destinationId={destinationId}
+                          parachainInfo={parachainsInfo}
+                          beneficiary={beneficiary}
+                          handleSufficientTokens={handleSufficientTokens}
+                          handleTopUpCheck={handleTopUpCheck}
+                          handleBalanceCheck={handleBalanceCheck}
+                        />
+                      </>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="beneficiary"
+                render={({ field }) => (
+                  <FormItem {...field}>
+                    <FormLabel>Beneficiary</FormLabel>
+                    <FormDescription className="hidden md:flex">
+                      Receiver account on the destination.
+                    </FormDescription>
+                    <FormControl>
+                      <SelectAccount
+                        accounts={beneficiaries}
+                        field={field}
+                        allowManualInput={false}
+                        disabled={true}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex space-x-2">
+                <div className="w-2/3">
+                  <FormField
+                    control={form.control}
+                    name="amount"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Amount</FormLabel>
+                        <FormControl>
+                          <Input type="string" placeholder="0.0" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className="w-1/3">
+                  <FormItem>
+                    <FormLabel>Unit</FormLabel>
+                    <div className="flex h-10 w-full rounded-md bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50">
+                      {tokenSymbol}
+                    </div>
+                  </FormItem>
+                </div>
+              </div>
+              <div className="text-sm text-right text-muted-foreground px-1">
+                Transfer Fee: {feeDisplay}
+                <br />
+                {sourceId === "assethub" ? null : (
+                  <>
+                    {" "}
+                    XCM Fee:{" "}
+                    {formatBalance({
+                      number: BigInt(topUpCheck.xcmFee),
+                      decimals:
+                        parachainsInfo.find(({ id }) => id === sourceId)
+                          ?.switchPair?.[0].xcmFee.decimals ?? 10, // fallback to denomination of polkadot.
+
+                      displayDecimals: 3,
+                    })}{" "}
+                    {
+                      parachainsInfo.find(({ id }) => id === sourceId)
+                        ?.switchPair[0].xcmFee.symbol
+                    }
+                  </>
+                )}
+              </div>
+              <br />
+              {topUpCheck.xcmFee >= topUpCheck.xcmBalance &&
+              sourceId !== "assethub" ? (
+                <TopUpXcmFee
+                  sourceAccount={sourceAccount ?? ""}
+                  beneficiary={beneficiary}
+                  targetChainInfo={
+                    // target for transfer is source of switch
+                    parachainsInfo.find(({ id }) => id === sourceId)!
+                  }
+                  parachainSufficientTokenAvailable={
+                    parachainSufficientTokenAvailable
+                  }
+                  assetHubSufficientTokenAvailable={
+                    assetHubSufficientTokenAvailable
+                  }
+                  polkadotAccounts={polkadotAccounts!}
+                  xcmBalance={topUpCheck.xcmBalance}
+                  xcmBalanceDestination={topUpCheck.xcmBalanceDestination}
+                  formData={form.getValues()}
+                  destinationId={destinationId}
+                />
+              ) : (
+                <Button
+                  disabled={!transaction}
+                  className="w-full my-8"
+                  type="submit"
+                >
+                  Submit
+                </Button>
+              )}
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+      <BusyDialog open={busyMessage !== ""} description={busyMessage} />
+      <SendErrorDialog
+        info={error}
+        formData={form.getValues()}
+        dismiss={() => setError(null)}
+      />
+    </>
+  );
+};

--- a/components/TermsOfUse.tsx
+++ b/components/TermsOfUse.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { acceptedTermsOfUseAtom } from "@/store/termsOfUse";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import {
   Dialog,
   DialogContent,

--- a/components/TopUpXcmFee.tsx
+++ b/components/TopUpXcmFee.tsx
@@ -1,0 +1,309 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./ui/dialog";
+import { toPolkadot } from "@snowbridge/api";
+import { useState, useCallback, FC, useMemo } from "react";
+import { Button } from "./ui/button";
+
+import { BusyDialog } from "./BusyDialog";
+import { Input } from "./ui/input";
+import { ErrorInfo, FormDataSwitch, FormData } from "@/utils/types";
+import { useAtomValue } from "jotai";
+import { snowbridgeContextAtom } from "@/store/snowbridge";
+import { ParaConfig } from "@/utils/parachainConfigs";
+
+import { parseUnits } from "ethers";
+import { decodeAddress } from "@polkadot/util-crypto";
+import { WalletAccount } from "@talismn/connect-wallets";
+import { formatBalance } from "@/utils/formatting";
+import { toast } from "sonner";
+import { SendErrorDialog } from "./SendErrorDialog";
+
+interface Props {
+  sourceAccount: string;
+  targetChainInfo: ParaConfig;
+  beneficiary: string;
+  parachainSufficientTokenAvailable: boolean;
+  assetHubSufficientTokenAvailable: boolean;
+  polkadotAccounts: WalletAccount[];
+  xcmBalance: bigint;
+  xcmBalanceDestination: bigint;
+  formData: FormData | FormDataSwitch;
+  destinationId: string;
+}
+
+export const TopUpXcmFee: FC<Props> = ({
+  sourceAccount,
+  targetChainInfo,
+  beneficiary,
+  parachainSufficientTokenAvailable,
+  polkadotAccounts,
+  xcmBalance,
+  xcmBalanceDestination,
+  formData,
+  destinationId,
+}) => {
+  const context = useAtomValue(snowbridgeContextAtom);
+
+  const { switchPair, parachainId } = targetChainInfo;
+
+  const xcmFee = useMemo(() => {
+    if (!switchPair || !switchPair[0]) return null;
+    return formatBalance({
+      number: BigInt(switchPair[0].xcmFee.amount),
+      decimals: switchPair[0].xcmFee.decimals,
+      displayDecimals: 3,
+    });
+  }, [switchPair]);
+
+  const [busyMessage, setBusyMessage] = useState("");
+
+  const [amountInput, setAmountInput] = useState("");
+
+  const [error, setError] = useState<ErrorInfo | null>(null);
+
+  const [openState, setOpen] = useState(false);
+
+  const submitTopUp = useCallback(async () => {
+    if (!context || !switchPair || !xcmFee) return;
+    try {
+      const parsedInput = parseUnits(
+        amountInput,
+        switchPair[0].xcmFee.decimals,
+      );
+
+      if (
+        parsedInput + xcmBalance <
+        parseUnits(xcmFee, switchPair[0].xcmFee.decimals)
+      ) {
+        setError({
+          title: "Not Enough to cover fees",
+          description: "The amount is too low to cover the XCM fees",
+          errors: [],
+        });
+        return;
+      }
+
+      if (xcmBalanceDestination < parsedInput) {
+        setError({
+          title: "Balance too low",
+          description: "XCM Balance is too low for the amount specified",
+          errors: [],
+        });
+        return;
+      }
+
+      if (!parachainSufficientTokenAvailable) {
+        setError({
+          title: "Not Enough Sufficient tokens",
+          description: "Please follow the sufficient or existential deposit",
+          errors: [
+            {
+              kind: "toPolkadot",
+              code: toPolkadot.SendValidationCode.BeneficiaryAccountMissing,
+              message:
+                "Asset Hub requires that you hold specific tokens in order for an account to be active.",
+            },
+          ],
+        });
+        return;
+      }
+
+      setBusyMessage("Transaction being created.");
+      const api = context.polkadot.api.assetHub;
+
+      const tx = api.tx.polkadotXcm.limitedReserveTransferAssets(
+        {
+          V4: {
+            parents: 1,
+            interior: {
+              X1: [{ Parachain: parachainId }],
+            },
+          },
+        },
+        {
+          V4: {
+            parents: 0,
+            interior: {
+              X1: [
+                {
+                  AccountId32: {
+                    id: decodeAddress(beneficiary),
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          V4: [
+            {
+              id: switchPair[0].xcmFee.remoteXcmFee.V4.id,
+              fun: {
+                Fungible: parsedInput,
+              },
+            },
+          ],
+        },
+        0,
+        "Unlimited",
+      );
+
+      const { signer, address } = polkadotAccounts?.find(
+        (val: WalletAccount) => val.address === sourceAccount,
+      )!;
+
+      if (!signer) {
+        throw new Error("Signer is not available");
+      }
+
+      setBusyMessage("Transaction in flight.");
+      const subscanHost =
+        destinationId === "assethub"
+          ? "https://assethub-polkadot.subscan.io"
+          : "https://spiritnet.subscan.io";
+      await tx.signAndSend(address, { signer }, (result) => {
+        setBusyMessage("Currently in flight");
+
+        if (result.isFinalized && !result.dispatchError) {
+          setOpen(false);
+          setBusyMessage("");
+          toast.info("Transfer Successful", {
+            position: "bottom-center",
+            closeButton: true,
+            duration: 60000,
+            id: "transfer_success",
+            description: "Token transfer was succesfully initiated.",
+            important: true,
+            action: {
+              label: "View",
+              onClick: () =>
+                window.open(
+                  `${subscanHost}/extrinsic/${result.txHash}`,
+                  "_blank",
+                ),
+            },
+          });
+        } else if (result.isError || result.dispatchError) {
+          setBusyMessage("");
+          toast.info("Transfer unsuccessful", {
+            position: "bottom-center",
+            closeButton: true,
+            duration: 60000,
+            id: "transfer_error",
+            description: "Token transfer was unsuccesful.",
+            important: true,
+            action: {
+              label: "View",
+              onClick: () =>
+                window.open(
+                  `${subscanHost}/extrinsic/${result.txHash}`,
+                  "_blank",
+                ),
+            },
+          });
+        }
+      });
+      setBusyMessage("");
+    } catch (error) {
+      console.error(error);
+      setBusyMessage("");
+      setError({
+        title: "Transaction Failed",
+        description: `Error occured while trying to send transaction.`,
+        errors: [],
+      });
+    }
+  }, [
+    context,
+    switchPair,
+    xcmFee,
+    destinationId,
+    amountInput,
+    xcmBalance,
+    xcmBalanceDestination,
+    parachainSufficientTokenAvailable,
+    parachainId,
+    beneficiary,
+    polkadotAccounts,
+    sourceAccount,
+  ]);
+
+  return (
+    <>
+      <Dialog open={openState} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button className="w-full my-8">Submit</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>XCM Fee Transfer</DialogTitle>
+          </DialogHeader>
+          <p>
+            Not enough {switchPair ? switchPair[0].xcmFee.symbol : null} for XCM
+            transaction.
+          </p>
+          <p>Send required XCM funds from Asset Hub to Source Parachain.</p>
+          <DialogDescription className="flex items-center py-2">
+            From: {sourceAccount}
+            <br />
+            XCM Fee Balance:{" "}
+            {formatBalance({
+              number: BigInt(xcmBalance),
+              decimals: switchPair[0].xcmFee.decimals,
+              displayDecimals: 3,
+            })}{" "}
+            {switchPair[0].xcmFee.symbol}
+          </DialogDescription>
+          <DialogDescription className="flex items-center py-2">
+            To: {beneficiary}
+            <br />
+            XCM Fee Balance:{" "}
+            {formatBalance({
+              number: BigInt(xcmBalanceDestination),
+              decimals: switchPair[0].xcmFee.decimals,
+              displayDecimals: 3,
+            })}{" "}
+            {switchPair[0].xcmFee.symbol}
+          </DialogDescription>
+          <Input
+            id="amountInput"
+            type="string"
+            value={amountInput}
+            placeholder={xcmFee ?? "0"}
+            onChange={(e) => setAmountInput(e.target.value)}
+          />
+          <DialogDescription className="flex items-center">
+            Current XCM Fee: {xcmFee}{" "}
+            {switchPair ? switchPair[0].xcmFee.symbol : null}
+          </DialogDescription>
+
+          <DialogFooter>
+            <Button
+              className="w-full my-8"
+              type="submit"
+              onClick={() => submitTopUp()}
+              disabled={
+                !context || !beneficiary || !sourceAccount || !amountInput
+              }
+            >
+              Top Up
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <BusyDialog open={busyMessage !== ""} description={busyMessage} />
+      <SendErrorDialog
+        info={error}
+        formData={formData}
+        dismiss={() => setError(null)}
+      />
+    </>
+  );
+};

--- a/hooks/useSnowbridgeContext.ts
+++ b/hooks/useSnowbridgeContext.ts
@@ -7,16 +7,28 @@ import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
 import { AlchemyProvider } from "ethers";
 import { createContext } from "@/lib/snowbridge";
+import {
+  parachainConfigs,
+  SnowbridgeEnvironmentNames,
+} from "@/utils/parachainConfigs";
 
 const createSnowbridgeContext = async (
   env: environment.SnowbridgeEnvironment,
   alchemyKey: string,
 ) => {
   const ethereumProvider = new AlchemyProvider(env.ethChainId, alchemyKey);
+  const parachainEndpoints = new Set(env.config.PARACHAINS);
+  // merge transfer and switch component parachain endpoints
+  parachainConfigs[env.name as SnowbridgeEnvironmentNames].forEach(
+    ({ endpoint }) => {
+      parachainEndpoints.add(endpoint);
+    },
+  );
   const context = await createContext(ethereumProvider, env, {
     bridgeHub: process.env.NEXT_PUBLIC_BRIDGE_HUB_URL,
     assetHub: process.env.NEXT_PUBLIC_ASSET_HUB_URL,
     relaychain: process.env.NEXT_PUBLIC_RELAY_CHAIN_URL,
+    parachains: Array.from(parachainEndpoints),
   });
   return context;
 };

--- a/lib/snowbridge.ts
+++ b/lib/snowbridge.ts
@@ -30,7 +30,9 @@ export function getEnvironmentName() {
 
 export function getEnvironment() {
   const envName = getEnvironmentName();
-  const env = environment.SNOWBRIDGE_ENV[envName];
+  const env: environment.SnowbridgeEnvironment =
+    environment.SNOWBRIDGE_ENV[envName];
+
   if (env === undefined)
     throw new Error(
       `NEXT_PUBLIC_SNOWBRIDGE_ENV configured for unknown environment '${envName}'`,
@@ -201,6 +203,7 @@ export type ContextOverrides = {
   bridgeHub?: string;
   assetHub?: string;
   relaychain?: string;
+  parachains?: string[];
 };
 
 export async function createContext(
@@ -208,7 +211,7 @@ export async function createContext(
   { config }: SnowbridgeEnvironment,
   overrides?: ContextOverrides,
 ) {
-  return await contextFactory({
+  return contextFactory({
     ethereum: {
       execution_url: ethereumProvider,
       beacon_url: config.BEACON_HTTP_API,
@@ -218,7 +221,7 @@ export async function createContext(
         bridgeHub: overrides?.bridgeHub ?? config.BRIDGE_HUB_URL,
         assetHub: overrides?.assetHub ?? config.ASSET_HUB_URL,
         relaychain: overrides?.relaychain ?? config.RELAY_CHAIN_URL,
-        parachains: config.PARACHAINS,
+        parachains: overrides?.parachains ?? config.PARACHAINS,
       },
     },
     appContracts: {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toggle": "^1.1.0",
-    "@snowbridge/api": "^0.1.22",
-    "@snowbridge/contract-types": "^0.1.22",
+    "@snowbridge/api": "^0.1.23",
+    "@snowbridge/contract-types": "^0.1.23",
     "@talismn/connect-components": "^1.1.8",
     "@talismn/connect-wallets": "^1.2.5",
     "@types/big.js": "^6.2.2",
@@ -76,5 +76,6 @@
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2"
-  }
+  },
+  "packageManager": "pnpm@9.12.0+sha512.4abf725084d7bcbafbd728bfc7bee61f2f791f977fd87542b3579dcb23504d170d46337945e4c66485cd12d588a0c0e570ed9c477e7ccdd8507cf05f3f92eaca"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,11 +54,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@snowbridge/api':
-        specifier: ^0.1.22
-        version: 0.1.22(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
+        specifier: ^0.1.23
+        version: 0.1.23(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)
       '@snowbridge/contract-types':
-        specifier: ^0.1.22
-        version: 0.1.22(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        specifier: ^0.1.23
+        version: 0.1.23(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@talismn/connect-components':
         specifier: ^1.1.8
         version: 1.1.8(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/extension-inject@0.47.3(@polkadot/api@11.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@polkadot/util@12.6.2)(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
@@ -1350,11 +1350,11 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@snowbridge/api@0.1.22':
-    resolution: {integrity: sha512-0PockMMWtz02x6p7zQ0rqVy9F06vB2GyYMqwafevLT8tAAXYHceZ068s8yGPygu7Bv2SIL767AmPqvVbMa0S1w==}
+  '@snowbridge/api@0.1.23':
+    resolution: {integrity: sha512-/BYUgEnzYrQ3eWOgnhfr/+AlLaUN61vPtCW721gY9l3Gv03e1ah1VtkPy6jLjHn4Kx5jPmrNNCicBzb2HEB5RQ==}
 
-  '@snowbridge/contract-types@0.1.22':
-    resolution: {integrity: sha512-fSimV6LQzUQRVYBb3NILd4sCLEpYws/basoJpd9fOvnv9Q1rOfd+2ggkGLo1MqrbOF2V7oLeb7rEDY6Jwat9/w==}
+  '@snowbridge/contract-types@0.1.23':
+    resolution: {integrity: sha512-ZitMkXkx/ut5mcgxABP56xJSCuch8PL8A9YWxUFUzOrNSOD2gvwvLGgkZuctM98EPD0aA+rrJe4xdlXYtPu28w==}
 
   '@stablelib/aead@1.0.1':
     resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
@@ -6669,14 +6669,14 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@snowbridge/api@0.1.22(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
+  '@snowbridge/api@0.1.23(bufferutil@4.0.8)(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@polkadot/api': 11.3.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
       '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
       '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
-      '@snowbridge/contract-types': 0.1.22(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@snowbridge/contract-types': 0.1.23(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.6.2))(typescript@5.6.2)
       ethers: 6.13.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       rxjs: 7.8.1
@@ -6687,7 +6687,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@snowbridge/contract-types@0.1.22(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@snowbridge/contract-types@0.1.23(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       ethers: 6.13.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -8454,7 +8454,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
       eslint-plugin-react: 7.37.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -8489,7 +8489,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -8507,7 +8507,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -3,14 +3,10 @@ import { Context, assets, environment } from "@snowbridge/api";
 import SnowbridgeEnvironment = environment.SnowbridgeEnvironment;
 import { formatBalance } from "@/utils/formatting";
 import { ErrorInfo } from "./types";
-import { parseUnits } from "ethers";
-
-export function parseAmount(
-  decimals: string,
-  metadata: assets.ERC20Metadata,
-): bigint {
-  return parseUnits(decimals, metadata.decimals);
-}
+import { ApiPromise } from "@polkadot/api";
+import { RemoteAssetId } from "./types";
+import { Option } from "@polkadot/types";
+import { AssetBalance } from "@polkadot/types/interfaces";
 
 async function getTokenBalance({
   context,
@@ -98,4 +94,21 @@ export function updateBalance(
         errors: [],
       });
     });
+}
+
+export async function fetchForeignAssetsBalances(
+  api: ApiPromise,
+  remoteAssetId: RemoteAssetId,
+  sourceAccount: string,
+  decimals: number,
+) {
+  const foreignAssets = await api.query.foreignAssets.account<
+    Option<AssetBalance>
+  >(remoteAssetId, sourceAccount);
+
+  return formatBalance({
+    number: foreignAssets.unwrapOrDefault().balance.toBigInt(),
+    decimals,
+    displayDecimals: 3,
+  });
 }

--- a/utils/formSchema.ts
+++ b/utils/formSchema.ts
@@ -1,6 +1,32 @@
 "use client";
 import { z } from "zod";
 
+export const formSchemaSwitch = z.object({
+  source: z.string(),
+  destination: z.string(),
+  token: z.string().min(1, "Select token."),
+  amount: z
+    .string()
+    .regex(
+      /^([1-9][0-9]{0,37})|([0-9]{0,37}\.+[0-9]{0,18})$/,
+      "Invalid amount",
+    ),
+  beneficiary: z
+    .string()
+    .min(1, "Select beneficiary.")
+    .regex(
+      /^(0x[A-Fa-f0-9]{32})|(0x[A-Fa-f0-9]{20})|([A-Za-z0-9]{47,48})$/,
+      "Invalid address format.",
+    ),
+  sourceAccount: z
+    .string()
+    .min(1, "Select source account.")
+    .regex(
+      /^(0x[A-Fa-f0-9]{32})|(0x[A-Fa-f0-9]{20})|([A-Za-z0-9]{47,48})$/,
+      "Invalid address format.",
+    ),
+});
+
 export const formSchema = z.object({
   source: z.string().min(1, "Select source."),
   destination: z.string().min(1, "Select destination."),

--- a/utils/onSubmit.ts
+++ b/utils/onSubmit.ts
@@ -10,6 +10,7 @@ import {
   toEthereum,
   toPolkadot,
 } from "@snowbridge/api";
+import { parseUnits } from "ethers";
 import { WalletAccount } from "@talismn/connect-wallets";
 import { BrowserProvider } from "ethers";
 import { Dispatch, SetStateAction } from "react";
@@ -17,9 +18,8 @@ import { UseFormReturn } from "react-hook-form";
 import { toast } from "sonner";
 import { track } from "@vercel/analytics";
 import { errorMessage } from "./errorMessage";
-import { parseAmount } from "@/utils/balances";
 import { AppRouter, FormData, ErrorInfo } from "@/utils/types";
-import { validateOFAC } from "@/components/Transfer";
+import { validateOFAC } from "@/utils/validateOFAC";
 
 export function onSubmit({
   context,
@@ -56,7 +56,10 @@ export function onSubmit({
     try {
       if (tokenMetadata == null) throw Error(`No erc20 token metadata.`);
 
-      const amountInSmallestUnit = parseAmount(data.amount, tokenMetadata);
+      const amountInSmallestUnit = parseUnits(
+        data.amount,
+        tokenMetadata.decimals,
+      );
       if (amountInSmallestUnit === 0n) {
         const errorMessage = "Amount must be greater than 0.";
         form.setError("amount", { message: errorMessage });

--- a/utils/onSwitch.ts
+++ b/utils/onSwitch.ts
@@ -1,0 +1,122 @@
+"use client";
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { Context } from "@snowbridge/api";
+import { PalletAssetSwitchSwitchSwitchPairInfo } from "@/utils/types";
+import { ISubmittableResult } from "@polkadot/types/types";
+import { decodeAddress } from "@polkadot/util-crypto";
+import { Option } from "@polkadot/types";
+
+export async function parachainToAssetHubTransfer({
+  context,
+  beneficiary,
+  parachainId,
+  amount,
+  palletName,
+}: {
+  context: Context | null;
+  beneficiary: string;
+  parachainId: number;
+  amount: bigint;
+  palletName: string;
+}): Promise<SubmittableExtrinsic<"promise", ISubmittableResult>> {
+  if (!context) {
+    throw Error("Invalid context: please update context");
+  }
+
+  const parachainApi = context.polkadot.api.parachains[parachainId];
+
+  const pathToBeneficiary = {
+    V3: {
+      parents: 0,
+      interior: {
+        X1: {
+          AccountId32: {
+            id: decodeAddress(beneficiary),
+          },
+        },
+      },
+    },
+  };
+
+  return parachainApi.tx[palletName].switch(amount, pathToBeneficiary);
+}
+
+export async function assetHubToParachainTransfer({
+  context,
+  beneficiary,
+  paraId,
+  palletName,
+  amount,
+}: {
+  context: Context | null;
+  beneficiary: string;
+  paraId: number;
+  palletName: string;
+  amount: bigint;
+}): Promise<SubmittableExtrinsic<"promise", ISubmittableResult>> {
+  if (!context) {
+    throw Error("Invalid context: please update context");
+  }
+
+  const assetHubApi = context.polkadot.api.assetHub;
+  const parachainApi = context.polkadot.api.parachains[paraId];
+
+  const switchPair =
+    await parachainApi.query[palletName].switchPair<
+      Option<PalletAssetSwitchSwitchSwitchPairInfo>
+    >();
+
+  const pathToBeneficiary = {
+    parents: 0,
+    interior: {
+      X1: [
+        {
+          AccountId32: {
+            id: decodeAddress(beneficiary),
+          },
+        },
+      ],
+    },
+  };
+  const pathToParachain = {
+    parents: 1,
+    interior: {
+      X1: [
+        {
+          Parachain: paraId,
+        },
+      ],
+    },
+  };
+
+  //@ts-ignore Due to the custom KILT typing
+  const remoteAssetId = switchPair.unwrap().remoteAssetId.asV4;
+
+  return assetHubApi.tx.polkadotXcm.transferAssetsUsingTypeAndThen(
+    {
+      V4: pathToParachain,
+    },
+    {
+      V4: [
+        {
+          id: remoteAssetId,
+          fun: { Fungible: amount },
+        },
+      ],
+    },
+    "LocalReserve",
+    { V4: remoteAssetId },
+    "LocalReserve",
+    {
+      V4: [
+        {
+          DepositAsset: {
+            assets: { Wild: "All" },
+            beneficiary: pathToBeneficiary,
+          },
+        },
+      ],
+    },
+    "Unlimited",
+  );
+}

--- a/utils/parachainConfigs.ts
+++ b/utils/parachainConfigs.ts
@@ -1,0 +1,239 @@
+import { TransferLocation } from "@snowbridge/api/dist/environment";
+import { SwitchPair } from "./types";
+
+export type SnowbridgeEnvironmentNames =
+  | "local_e2e"
+  | "rococo_sepolia"
+  | "polkadot_mainnet"
+  | "paseo_sepolia"
+  | "westend_sepolia";
+
+export interface ParaConfig {
+  id: string;
+  name: string;
+  nativeTokenMetadata: {
+    symbol: string;
+    decimals: number;
+  };
+  switchPair: SwitchPair;
+  endpoint: string;
+  parachainId: number;
+}
+
+type ParaConfigsForSnowEnv = Record<SnowbridgeEnvironmentNames, ParaConfig[]>;
+
+export const parachainConfigs: ParaConfigsForSnowEnv = {
+  local_e2e: [],
+  westend_sepolia: [],
+  polkadot_mainnet: [
+    {
+      // Kilt on Polkadot
+      id: "spiritnet",
+      name: "KILT",
+      endpoint: "wss://spiritnet.kilt.io/",
+      switchPair: [
+        {
+          id: "assetSwitchPool1",
+          tokenMetadata: {
+            symbol: "KILT",
+            decimals: 15,
+            minimumTransferAmount: "10000000000000",
+          },
+          xcmFee: {
+            symbol: "DOT",
+            decimals: 10,
+            locationId: "assethub",
+            amount: "5000000000",
+            remoteXcmFee: {
+              V4: {
+                id: {
+                  parents: 1,
+                  interior: "Here",
+                },
+                fun: {
+                  Fungible: 5000000000,
+                },
+              },
+            },
+          },
+          remoteAssetId: {
+            parents: 2,
+            interior: {
+              X2: [
+                {
+                  GlobalConsensus: {
+                    Ethereum: {
+                      chainId: "1",
+                    },
+                  },
+                },
+                {
+                  AccountKey20: {
+                    network: null,
+                    key: "0x5d3d01fd6d2ad1169b17918eb4f153c6616288eb",
+                  },
+                },
+              ],
+            },
+          },
+          remoteReserveLocation: {
+            parents: 1,
+            interior: {
+              X1: [
+                {
+                  Parachain: 1000,
+                },
+              ],
+            },
+          },
+        },
+      ],
+      parachainId: 2086,
+      nativeTokenMetadata: {
+        symbol: "KILT",
+        decimals: 15,
+      },
+    },
+  ],
+  rococo_sepolia: [
+    {
+      // Kilt on rococo_sepolia
+      id: "rilt",
+      name: "RILT",
+      endpoint: "wss://rilt.kilt.io",
+      switchPair: [
+        {
+          id: "assetSwitchPool1",
+          tokenMetadata: {
+            symbol: "RILT",
+            decimals: 15,
+            minimumTransferAmount: "10000000000000",
+          },
+          xcmFee: {
+            symbol: "ROC",
+            decimals: 10,
+            locationId: "assethub",
+            amount: "10000000000",
+            remoteXcmFee: {
+              V4: {
+                id: {
+                  parents: 1,
+                  interior: "Here",
+                },
+                fun: {
+                  Fungible: 1000000000000,
+                },
+              },
+            },
+          },
+          remoteAssetId: {
+            parents: 2,
+            interior: {
+              X2: [
+                {
+                  GlobalConsensus: {
+                    Ethereum: {
+                      chainId: "11155111",
+                    },
+                  },
+                },
+                {
+                  AccountKey20: {
+                    network: null,
+                    key: "0x45Ffe5A44Dae5438Ee7FdD26EE5bEFaD13d52832",
+                  },
+                },
+              ],
+            },
+          },
+          remoteReserveLocation: {
+            parents: 1,
+            interior: {
+              X1: [
+                {
+                  Parachain: 1000,
+                },
+              ],
+            },
+          },
+        },
+      ],
+      parachainId: 4504,
+      nativeTokenMetadata: {
+        symbol: "RILT",
+        decimals: 15,
+      },
+    },
+  ],
+  paseo_sepolia: [
+    {
+      // Kilt on paseo_sepolia
+      id: "pilt",
+      name: "PILT",
+      endpoint: "wss://peregrine.kilt.io/parachain-public-ws/",
+      switchPair: [
+        {
+          id: "assetSwitchPool1",
+          tokenMetadata: {
+            symbol: "PILT",
+            decimals: 15,
+            minimumTransferAmount: "10000000000000",
+          },
+          xcmFee: {
+            symbol: "PAS",
+            decimals: 10,
+            locationId: "assethub",
+            amount: "5000000000",
+            remoteXcmFee: {
+              V4: {
+                id: {
+                  parents: 1,
+                  interior: "Here",
+                },
+                fun: {
+                  Fungible: 5000000000,
+                },
+              },
+            },
+          },
+          remoteAssetId: {
+            parents: 2,
+            interior: {
+              X2: [
+                {
+                  GlobalConsensus: {
+                    Ethereum: {
+                      chainId: "11155111",
+                    },
+                  },
+                },
+                {
+                  AccountKey20: {
+                    network: null,
+                    key: "0x99E743964C036bc28931Fb564817db428Aa7f752",
+                  },
+                },
+              ],
+            },
+          },
+
+          remoteReserveLocation: {
+            parents: 1,
+            interior: {
+              X1: [
+                {
+                  Parachain: 1000,
+                },
+              ],
+            },
+          },
+        },
+      ],
+      parachainId: 2086,
+      nativeTokenMetadata: {
+        symbol: "PILT",
+        decimals: 15,
+      },
+    },
+  ],
+};

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,5 +1,8 @@
 import { type useRouter } from "next/navigation";
-import { toPolkadot, toEthereum } from "@snowbridge/api";
+import { toPolkadot, toEthereum, environment } from "@snowbridge/api";
+import { Struct, u128 } from "@polkadot/types";
+import { AccountId32 } from "@polkadot/types/interfaces";
+import { Codec } from "@polkadot/types/types";
 
 export type AppRouter = ReturnType<typeof useRouter>;
 export type ValidationError =
@@ -12,6 +15,15 @@ export type ErrorInfo = {
   errors: ValidationError[];
 };
 
+export type FormDataSwitch = {
+  source: string;
+  sourceAccount: string;
+  destination: string;
+  token: string;
+  amount: string;
+  beneficiary: string;
+};
+
 export type FormData = {
   source: string;
   sourceAccount: string;
@@ -20,8 +32,85 @@ export type FormData = {
   amount: string;
   beneficiary: string;
 };
+
 export type AccountInfo = {
   key: string;
   name: string;
   type: "substrate" | "ethereum";
 };
+
+export type TokenMetadata = {
+  symbol: string;
+  decimals: number;
+  minimumTransferAmount: string;
+};
+
+export type XcmFee = {
+  symbol: string;
+  decimals: number;
+  locationId: string;
+  amount: string;
+  remoteXcmFee: {
+    V4: {
+      id: {
+        parents: number;
+        interior: any;
+      };
+      fun: {
+        Fungible: number;
+      };
+    };
+  };
+};
+
+export type RemoteAssetId = {
+  parents: number;
+  interior: {
+    X2: (
+      | {
+          GlobalConsensus: {
+            Ethereum: {
+              chainId: string;
+            };
+          };
+        }
+      | {
+          AccountKey20: {
+            network: null;
+            key: string;
+          };
+        }
+    )[];
+  };
+};
+
+export type RemoteReserveLocation = {
+  parents: number;
+  interior: {
+    X1: {
+      Parachain: number;
+    }[];
+  };
+};
+
+export type SwitchPairEntry = {
+  id: string;
+  tokenMetadata: TokenMetadata;
+  xcmFee: XcmFee;
+  remoteAssetId: RemoteAssetId;
+  remoteReserveLocation: RemoteReserveLocation;
+};
+
+export type SwitchPair = SwitchPairEntry[];
+
+export interface PalletAssetSwitchSwitchSwitchPairInfo extends Struct {
+  readonly poolAccount: AccountId32;
+  readonly remoteAssetCirculatingSupply: u128;
+  readonly remoteAssetEd: u128;
+  readonly remoteAssetId: Codec;
+  readonly remoteAssetTotalSupply: u128;
+  readonly remoteReserveLocation: Codec;
+  readonly remoteXcmFee: Codec;
+  readonly status: Codec;
+  readonly remoteAssetSovereignTotalBalance: u128;
+}

--- a/utils/userFriendlyErrorMessage.ts
+++ b/utils/userFriendlyErrorMessage.ts
@@ -1,13 +1,13 @@
 "use client";
 import { toEthereum, toPolkadot } from "@snowbridge/api";
-import { ValidationError, FormData } from "./types";
+import { ValidationError, FormData, FormDataSwitch } from "./types";
 
 export function userFriendlyErrorMessage({
   error,
   formData,
 }: {
   error: ValidationError;
-  formData: FormData;
+  formData: FormData | FormDataSwitch;
 }) {
   if (error.kind === "toPolkadot") {
     if (

--- a/utils/validateOFAC.ts
+++ b/utils/validateOFAC.ts
@@ -1,0 +1,37 @@
+"use client";
+import { UseFormReturn } from "react-hook-form";
+import { FormData } from "./types";
+
+export const validateOFAC = async (
+  data: FormData,
+  form: UseFormReturn<FormData>,
+): Promise<boolean> => {
+  const response = await fetch("/blocked/api", {
+    method: "POST",
+    body: JSON.stringify({
+      sourceAddress: data.sourceAccount,
+      beneficiaryAddress: data.beneficiary,
+    }),
+  });
+  if (!response.ok) {
+    throw Error(
+      `Error verifying ofac status: ${response.status} - ${response.statusText}`,
+    );
+  }
+  const result = await response.json();
+  if (result.beneficiaryBanned) {
+    form.setError(
+      "beneficiary",
+      { message: "Beneficiary banned." },
+      { shouldFocus: true },
+    );
+  }
+  if (result.sourceBanned) {
+    form.setError(
+      "sourceAccount",
+      { message: "Source Account banned." },
+      { shouldFocus: true },
+    );
+  }
+  return result.beneficiaryBanned === false && result.sourceBanned === false;
+};


### PR DESCRIPTION
* refactor: seperation of concern and removal of types and utilty into utils

* refactor: moving util funct into utils folder out of transfer

* refactor: naming to match components convention

* refactor: moving types into utils

* refactor: import updates

* fix: error during environment configuration

* feat: adding eslint and prettier rules for consistent formatting

* style: reverting and fixing eslint and prettier formatting

* refactor: updating the utils and imports

* style: updating to the eslint rules

* refactor: merging the balances into a singluar util file

* style: updating to the latest eslint rules and config

* feat: env.example

* refactor: updating the eslint config

* refactor: updating the react ts to ts

* revert: fixing shadcn to revert back to original

* fix: moving the ignores to first as it doesnt ignore otherwise

* fix: missed lib utils

* fix: changing the names from lowercase to uppercase

* fix: renaming rest of files

* feat: creating a new tab for switch native token to erc20 via asset hub

* feat: adding the hard coded functions to switch tokens

* feat: adding the parachain configss

* feat: adding the parachains into the env at snowbirdge ts

* feat: updating naming in config to match the finder in submit transfer

* feat: adding a switch typing for the form data

* feat: expanding the zod typing to have validatiion of the object

* feat: updating the switch logic to handle the form to add dynamic para from the hard coded

* feat: updating the balance to fetch values

* feat: adding the switch tab

* feat: updating the error handling dialog to include form data switch and optional func

* feat: updating the switch component to include improvements

* feat: adding the token metadata fetching

* feat: made a new balance component to fetch the balances

* feat: updating to include fees adding use memo and callback to better handle state updates

* feat: updating the balances to handle the balance better

* feat: updating the onsubmit to handle the transactions and busy message better

* refactor: moving switch functionality into a new file on switch and removal from on submit

* refactor: updating the imports

* feat: include RILT token into the Ethereums send and receive

* feat: removal of rilt from the transfer source and destination

* feat: handling the parachain configs in the source better and dynamic

* feat: updating the balance token metadata better

* refactor: removal of parse amount as libarary does this

* feat: adding the switch component

* feat: adding the fucntionality for switching

* feat: adding new changes to parachain config and snowbridge

* feat: updating the parachainConfig and adding paseo

* feat: updating the on switch

* feat: upgrading the parachain config to include better options

* refactor: updating the balances to be more verbose and better

* refactor: updating the balances to be more verbose and better

* feat: updating the xcm fee from the config and adding to the component

* feat: adding the correct token displayed

* refactor: fixing race condition

* refactor: fixing race condition in balances

* style: updating the switch icon;

* refactor: moving balance util functions to balances utils

* feat: handling the sufficent and xcm balance for the switch

* refactor: moving validate ofac to utils and out of transfer

* refactor: make a location selector component to increase readablilty

* refactor: props should be moved to type or interface

* feat: removal of xcm balance component

* feat: handle the balances and updating to make more dry

* feat: adding the top up xcm fee

* refactor: removal of to human and changing for unwarap default and handling better

* revert: adding logs back in from earlier

* feat: updating the history page to include paseo and polkadot js for rococo and peregine

* feat: updating the UI for the XCM fee componenet

* feat: updating search for pjs to fetch query from block as no subscan for testnet

* refactor: removing get formatted balance and replace with format balance

* style: update line break parachainconfig

* feat: updating display balance to 3 decimal

* refactor: updating the use effect to not update all callbacks

* refactor: using memo instead of use effect

* feat: adding debouncing to switch



* feat: updating the parachain config to match test and live networks

* refactor: making the typing more verbose

* refactor: fixing the race condition and setting error to null in new render

* refactor: fixing the race condition

* refactor: using use memo and find in location finder

* refactor: updating transfer to handle parachains not being included and switching filter to find

* refactor: updating the snowbridge to handle the paseo and other things correctly

* refactor: updating the typing and giving typing to balances handler

* refactor: updating name to create transaction

* feat: updating error handling and error description

* feat: updating error handling and error description and moved amount to memo and initial destination

* feat: handling errors

* feat: adding xcm fee top checks and balances with error hadnling

* feat: updating location selector balance

* feat: adding switch xcm balacne handling

* feat: adding error handling balances

* feat: adding typing for the polkadot api

* refactor: removing the paseo as newly exported from snowbridge api

* feat: removing the paseo sepolia from history as dupe

* refactor: simplify config and form values

* refactor: updating the balances to handle the source and dest

* refactor: simplify top up component

* fixup! refactor: simplify top up component

* fixup! refactor: updating the balances to handle the source and dest

* chore: bump snowbridge packages

* refactor: inline LocationSelector

* chore: force beneficiary to be sender for now

* chore: set token symbol

* refactor: updating balances and adding context to switch page

* feat: adding the exploreres to the westend and e2e for kilt

* feat: updating xcm balance and fee

* feat: adding more to balances

* chore: bigints everywhere

* feat: close top up modal after submission

* chore: fix error reporting

* chore: close top up modal when transaction is finalized

* feat: handling sufficients and formating big numbers for xcm

* fix: removing console logs

* chore: improve transaction error handling

* feat: handling fallback for xcm fee

* style: removing deadcode

* fix: updating the env file.

* fix: changingn name to fix the build step due to next folder structure requirements

* style: updating the balances names not to be the ids

* style: removed dead import

* fix: populate beneficiary on first load

* fix: updating the config fixes

* refactor: adding checks and fixing balance handling

* fix: do not create transaction on zero amount

* feat: adding the xcm fee

* chore: unset transaction on input change

* fix: subscan link for top up

* refactor: onSwitch helpers only create txs

* feat: adding better error handling from top xcm fee

* feat: removing polar path from the menu bar if westend

* fix: setting state in render

* refactor: select disable logic

* fix: don't fetch balance if account not set

* Revert "refactor: select disable logic"

This reverts commit a9dd77a1454cd579093d45c848ee1df7a340fc32.

* feat: name change

* feat: updating wording for the app

* chore: rename handleTransaction

* fix: token symbol default

* feat: handle if balance too low for transfer

* fix: add westend_sepolia key env to switch config

* fix: fee info not shown when top up needed

* chore: revert removing .env

* fix: updating the xcm fees

* fix: field validation not picking up on account selections

* chore: periodically refetch balances

* fix: re-add close on top-up success

* chore: reduce debounce to 700ms

* feat: handling the real balance excluding frozen

---------