### PR TITLE
Ignore history items without id

### DIFF
--- a/app/txcomplete/page.tsx
+++ b/app/txcomplete/page.tsx
@@ -113,7 +113,7 @@ function TxComponent() {
 
     const decoded = JSON.parse(base64url.decode(transferEncoded)) as Transfer;
     const history = data?.find(
-      (x) => x.id.toLowerCase() === decoded.id.toLowerCase(),
+      (x) => x.id?.toLowerCase() === decoded.id.toLowerCase(),
     );
     return [history ?? decoded, history !== undefined];
   }, [data, searchParams]);


### PR DESCRIPTION
Failed transfers such as [7906005-2](https://assethub-polkadot.subscan.io/extrinsic/7906005-2) will not have a message id. These are safe to ignore on the `txcomplete` page.