### PR TITLE
Filter out kusama events

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -220,9 +220,6 @@ const transferDetail = (
   registry: assetsV2.AssetRegistry,
 ): JSX.Element => {
   const { source, destination } = getEnvDetail(transfer, registry);
-  if (!source || !destination) {
-    return <div className="flex-col">No detail found.</div>;
-  }
   const links: { text: string; url: string }[] = getExplorerLinks(
     transfer,
     source,
@@ -376,9 +373,6 @@ export default function History() {
   const [transfersPendingLocal, setTransfersPendingLocal] = useAtom(
     transfersPendingLocalAtom,
   );
-
-  console.log("transferHistoryCache", transferHistoryCache)
-  console.log("transfersPendingLocal", transfersPendingLocal)
 
   const { data: assetRegistry } = useAssetRegistry();
   const {


### PR DESCRIPTION
Temporarily filter out kusama events so that the Indexer can be deployed with the Kusama changes without breaking the UI.