### PR TITLE
Show history item

### DIFF
--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -602,7 +602,9 @@ export default function Activity() {
         transfer.info.sourceAddress,
         transfer.info.beneficiaryAddress,
       );
-      if (!showGlobal && !transfer.isWalletTransaction) continue;
+      const isLinkedTransaction = hashItem && transfer.id === hashItem;
+      if (!showGlobal && !transfer.isWalletTransaction && !isLinkedTransaction)
+        continue;
 
       allTransfers.push(transfer);
     }
@@ -618,6 +620,7 @@ export default function Activity() {
     polkadotAccounts,
     ethereumAccounts,
     showGlobal,
+    hashItem,
   ]);
 
   useMemo(() => {


### PR DESCRIPTION
When linking a transaction, and the `global` button is not selected, the transaction doesn't show on the UI. This PR fixes it.